### PR TITLE
Potential fix workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/devops-maturity/devops-maturity/security/code-scanning/1](https://github.com/devops-maturity/devops-maturity/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with repository contents (e.g., checking out code), it only needs `contents: read` permissions. Adding this block at the root level of the workflow ensures that all jobs inherit these permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
