### PR TITLE
fix(deps): ignore unfixable transitive CVEs blocked by litellm on Python 3.14

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -63,17 +63,26 @@ def licenses(session):
 def vulnerability_scan(session):
     """Scan dependencies for known vulnerabilities."""
     session.install("pip-audit", ".")
-    # CVE-2026-40217 (litellm): fixed in 1.83.10, but 1.83.10+ requires
-    # python<3.14. Litellm 1.83.7 (last to support 3.14) pins python-dotenv
-    # to 1.0.1, which has CVE-2026-28684. Both blocked by upstream;
-    # ignore until upstream resolves the compatibility constraints.
+    # The ignored CVEs are all blocked by litellm's Python 3.14 support:
+    # litellm's fixes (1.83.10 / 1.83.14 / 1.84.0) all require python<3.14,
+    # but we still support Python 3.14, where litellm is pinned at 1.83.7
+    # (the last release supporting 3.14). 1.83.7 also pins python-dotenv==1.0.1
+    # (CVE-2026-28684). The aiohttp CVE batch is resolved by pinning
+    # aiohttp>=3.14.1 in pyproject.toml. Revisit once litellm restores 3.14
+    # support so these can be fixed instead of ignored.
     session.run(
         "pip-audit",
         "--local",
         "--ignore-vuln",
-        "CVE-2026-40217",
+        "CVE-2026-40217",  # litellm: fixed in 1.83.10 (requires python<3.14)
         "--ignore-vuln",
-        "CVE-2026-28684",
+        "CVE-2026-28684",  # python-dotenv: pinned to 1.0.1 by litellm 1.83.7
+        "--ignore-vuln",
+        "CVE-2026-47102",  # litellm: fixed in 1.83.10 (requires python<3.14)
+        "--ignore-vuln",
+        "CVE-2026-47101",  # litellm: fixed in 1.83.14 (requires python<3.14)
+        "--ignore-vuln",
+        "CVE-2026-49468",  # litellm: fixed in 1.84.0 (requires python<3.14)
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,23 +75,39 @@ def vulnerability_scan(session):
         "pip-audit",
         "--local",
         # litellm 1.83.7 and its hard-pinned dependencies
-        "--ignore-vuln", "CVE-2026-40217",  # litellm -> fixed in 1.83.10 (python<3.14)
-        "--ignore-vuln", "CVE-2026-47102",  # litellm -> fixed in 1.83.10 (python<3.14)
-        "--ignore-vuln", "CVE-2026-47101",  # litellm -> fixed in 1.83.14 (python<3.14)
-        "--ignore-vuln", "CVE-2026-49468",  # litellm -> fixed in 1.84.0 (python<3.14)
-        "--ignore-vuln", "CVE-2026-28684",  # python-dotenv 1.0.1 (pinned by litellm 1.83.7)
+        "--ignore-vuln",
+        "CVE-2026-40217",  # litellm -> fixed in 1.83.10 (python<3.14)
+        "--ignore-vuln",
+        "CVE-2026-47102",  # litellm -> fixed in 1.83.10 (python<3.14)
+        "--ignore-vuln",
+        "CVE-2026-47101",  # litellm -> fixed in 1.83.14 (python<3.14)
+        "--ignore-vuln",
+        "CVE-2026-49468",  # litellm -> fixed in 1.84.0 (python<3.14)
+        "--ignore-vuln",
+        "CVE-2026-28684",  # python-dotenv 1.0.1 (pinned by litellm 1.83.7)
         # aiohttp 3.13.5 (hard-pinned by litellm 1.83.7); all fixed in 3.14.x
-        "--ignore-vuln", "PYSEC-2026-237",
-        "--ignore-vuln", "CVE-2026-34993",
-        "--ignore-vuln", "CVE-2026-47265",
-        "--ignore-vuln", "CVE-2026-50269",
-        "--ignore-vuln", "CVE-2026-54273",
-        "--ignore-vuln", "CVE-2026-54274",
-        "--ignore-vuln", "CVE-2026-54276",
-        "--ignore-vuln", "CVE-2026-54277",
-        "--ignore-vuln", "CVE-2026-54278",
-        "--ignore-vuln", "CVE-2026-54279",
-        "--ignore-vuln", "CVE-2026-54280",
+        "--ignore-vuln",
+        "PYSEC-2026-237",
+        "--ignore-vuln",
+        "CVE-2026-34993",
+        "--ignore-vuln",
+        "CVE-2026-47265",
+        "--ignore-vuln",
+        "CVE-2026-50269",
+        "--ignore-vuln",
+        "CVE-2026-54273",
+        "--ignore-vuln",
+        "CVE-2026-54274",
+        "--ignore-vuln",
+        "CVE-2026-54276",
+        "--ignore-vuln",
+        "CVE-2026-54277",
+        "--ignore-vuln",
+        "CVE-2026-54278",
+        "--ignore-vuln",
+        "CVE-2026-54279",
+        "--ignore-vuln",
+        "CVE-2026-54280",
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -63,26 +63,35 @@ def licenses(session):
 def vulnerability_scan(session):
     """Scan dependencies for known vulnerabilities."""
     session.install("pip-audit", ".")
-    # The ignored CVEs are all blocked by litellm's Python 3.14 support:
-    # litellm's fixes (1.83.10 / 1.83.14 / 1.84.0) all require python<3.14,
-    # but we still support Python 3.14, where litellm is pinned at 1.83.7
-    # (the last release supporting 3.14). 1.83.7 also pins python-dotenv==1.0.1
-    # (CVE-2026-28684). The aiohttp CVE batch is resolved by pinning
-    # aiohttp>=3.14.1 in pyproject.toml. Revisit once litellm restores 3.14
-    # support so these can be fixed instead of ignored.
+    # Every advisory ignored below is a transitive issue blocked by litellm on
+    # Python 3.14. litellm 1.83.7 is the last release that supports Python 3.14,
+    # and it hard-pins aiohttp==3.13.5 and python-dotenv==1.0.1. The fixes for
+    # the aiohttp and litellm advisories ship only in newer releases that require
+    # python<3.14, so they cannot be applied while we still support 3.14
+    # (pinning a newer aiohttp directly is a ResolutionImpossible against
+    # litellm's exact pin). Revisit and drop these once litellm restores
+    # Python 3.14 support.
     session.run(
         "pip-audit",
         "--local",
-        "--ignore-vuln",
-        "CVE-2026-40217",  # litellm: fixed in 1.83.10 (requires python<3.14)
-        "--ignore-vuln",
-        "CVE-2026-28684",  # python-dotenv: pinned to 1.0.1 by litellm 1.83.7
-        "--ignore-vuln",
-        "CVE-2026-47102",  # litellm: fixed in 1.83.10 (requires python<3.14)
-        "--ignore-vuln",
-        "CVE-2026-47101",  # litellm: fixed in 1.83.14 (requires python<3.14)
-        "--ignore-vuln",
-        "CVE-2026-49468",  # litellm: fixed in 1.84.0 (requires python<3.14)
+        # litellm 1.83.7 and its hard-pinned dependencies
+        "--ignore-vuln", "CVE-2026-40217",  # litellm -> fixed in 1.83.10 (python<3.14)
+        "--ignore-vuln", "CVE-2026-47102",  # litellm -> fixed in 1.83.10 (python<3.14)
+        "--ignore-vuln", "CVE-2026-47101",  # litellm -> fixed in 1.83.14 (python<3.14)
+        "--ignore-vuln", "CVE-2026-49468",  # litellm -> fixed in 1.84.0 (python<3.14)
+        "--ignore-vuln", "CVE-2026-28684",  # python-dotenv 1.0.1 (pinned by litellm 1.83.7)
+        # aiohttp 3.13.5 (hard-pinned by litellm 1.83.7); all fixed in 3.14.x
+        "--ignore-vuln", "PYSEC-2026-237",
+        "--ignore-vuln", "CVE-2026-34993",
+        "--ignore-vuln", "CVE-2026-47265",
+        "--ignore-vuln", "CVE-2026-50269",
+        "--ignore-vuln", "CVE-2026-54273",
+        "--ignore-vuln", "CVE-2026-54274",
+        "--ignore-vuln", "CVE-2026-54276",
+        "--ignore-vuln", "CVE-2026-54277",
+        "--ignore-vuln", "CVE-2026-54278",
+        "--ignore-vuln", "CVE-2026-54279",
+        "--ignore-vuln", "CVE-2026-54280",
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ dependencies = [
   "itsdangerous",
   "httpx",
   "uvicorn",
+  # Transitive via litellm; pinned to clear the aiohttp CVE batch fixed in 3.14.x.
+  "aiohttp>=3.14.1",
   "litellm>=1.83.7,!=1.83.8,!=1.83.9",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,6 @@ dependencies = [
   "itsdangerous",
   "httpx",
   "uvicorn",
-  # Transitive via litellm; pinned to clear the aiohttp CVE batch fixed in 3.14.x.
-  "aiohttp>=3.14.1",
   "litellm>=1.83.7,!=1.83.8,!=1.83.9",
 ]
 


### PR DESCRIPTION
## Why

The `vulnerability_scan` (pip-audit) nox session is failing on `main` — a newly disclosed batch of **14 transitive CVEs** not covered by the ignore list:

```
aiohttp 3.13.5  → 11 advisories (PYSEC-2026-237, CVE-2026-34993, -47265, -50269, -54273/74/76/77/78/79/80)
litellm 1.83.7  → CVE-2026-49468, CVE-2026-47102, CVE-2026-47101
```

## Why they can't be fixed (the catch)

These are **transitively forced and unfixable while we support Python 3.14**:

- `litellm 1.83.7` is the **last release that supports Python 3.14**, and it **hard-pins `aiohttp==3.13.5`** and `python-dotenv==1.0.1`. Pinning a newer aiohttp directly is a `ResolutionImpossible` against that exact pin (the first attempt in this PR proved it).
- Every relevant fix — aiohttp `3.14.x`, litellm `1.83.10` / `1.83.14` / `1.84.0` — requires **`python<3.14`**.

So they cannot be remediated without dropping Python 3.14 support. Per maintainer decision, we keep 3.14 and **ignore** the advisories with rationale.

## What

**`noxfile.py`** — enumerate all affected advisories in the `pip-audit --ignore-vuln` list, grouped by package with per-line rationale, extending the existing `CVE-2026-40217` / `CVE-2026-28684` ignores. The comment block explains the root cause and the trigger for removal.

**`pyproject.toml`** — no change (the earlier aiohttp pin was reverted; it was unresolvable).

## Result

`pip-audit` goes from 14 unignored findings → 0, with every ignore documented.

## Follow-up

Track litellm restoring Python 3.14 support. Once it does, drop these ignores and upgrade. Until then, consider whether the AI feature warrants keeping litellm at all on 3.14, or version-splitting it so 3.10–3.13 users get the patched releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the vulnerability scanning setup to account for a broader set of known advisories.
  * Added clearer guidance around the audit configuration while keeping the existing local scan workflow intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->