### PR TITLE
feat(web): add /healthz endpoint + hosting/keep-warm guide

### DIFF
--- a/docs/deploy/hosting.md
+++ b/docs/deploy/hosting.md
@@ -1,0 +1,64 @@
+# Hosting & keep-warm
+
+The web interface is a small FastAPI app, so it runs comfortably on free
+hosting tiers. The one rough edge those tiers share is the **cold start**:
+platforms such as Render's free plan spin an instance down after a period
+of inactivity (around 15 minutes), and the next visitor has to wait while
+the container is started again.
+
+This page explains how to make the hosted demo feel instant.
+
+## The `/healthz` endpoint
+
+The app exposes a lightweight liveness probe:
+
+```text
+GET /healthz  ->  200 {"status": "ok", "version": "<app version>"}
+```
+
+It returns immediately without touching the database or rendering a
+template, which makes it cheap to call frequently — ideal as a keep-warm
+and uptime-monitor target.
+
+## Option 1 — Keep the instance warm (free)
+
+Point an external uptime monitor at the app so it never goes idle:
+
+1. Sign up for a free monitor such as [UptimeRobot](https://uptimerobot.com/)
+   or [cron-job.org](https://cron-job.org/).
+2. Add an HTTP(s) check for your deployment, e.g.
+   `https://<your-app>.onrender.com/healthz`.
+3. Set the interval to **5–10 minutes** (shorter than the host's idle
+   timeout).
+
+That keeps the container running, so visitors skip the cold start.
+
+!!! note "Free-tier hours"
+    Render's free plan includes a fixed number of instance-hours per month
+    (about 750). A single always-on service fits within that budget, but if
+    you run several free services they will share — and can exhaust — the
+    same pool. Prefer a dedicated uptime monitor over a CI cron job for
+    pinging: schedulers like GitHub Actions cron can drift by 15+ minutes,
+    which is longer than the idle timeout.
+
+## Option 2 — Use an always-on host (most reliable)
+
+If you would rather not rely on pinging:
+
+- **Render Starter** (paid) does not spin down — no code changes, just a
+  plan upgrade.
+- **[Fly.io](https://fly.io/)** can keep a minimum machine running
+  (`min_machines_running = 1`) so there is effectively no cold start.
+- **[Railway](https://railway.app/)** does not sleep services and bills by
+  usage.
+
+## Data persistence caveat
+
+By default the app stores assessments in a local SQLite database. On hosts
+with **ephemeral filesystems** (including Render's free tier), that file is
+reset on every spin-down and redeploy — registered users and assessment
+history will not survive. That is usually fine for a public demo.
+
+To retain data, point the app at a managed database (for example a free
+Postgres instance from Render, [Neon](https://neon.tech/), or
+[Supabase](https://supabase.com/)) instead of file-backed SQLite.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,8 @@ nav:
     - Maturity levels: reference/maturity-levels.md
     - Configuration: reference/configuration.md
     - CLI flags: reference/cli-flags.md
+  - Deploy:
+    - Hosting & keep-warm: deploy/hosting.md
 
 markdown_extensions:
   - admonition

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -37,6 +37,18 @@ app = FastAPI(
 )
 
 
+@app.get("/healthz")
+def healthz():
+    """Lightweight liveness probe.
+
+    Returns immediately without touching the database or rendering
+    templates, so it is cheap to call frequently. Use it as a
+    keep-warm / uptime-monitor target to avoid cold starts on hosts
+    that spin idle instances down (e.g. Render's free tier).
+    """
+    return {"status": "ok", "version": __version__}
+
+
 @app.get("/edit-assessment/{assessment_id}", response_class=HTMLResponse)
 def edit_assessment_form(request: Request, assessment_id: int):
     user = get_current_user(request)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -197,6 +197,17 @@ def test_badge_svg_endpoint():
     assert "svg" in response.headers.get("content-type", "").lower()
 
 
+# ── Health check ───────────────────────────────────────────────────────────────
+
+
+def test_healthz_endpoint():
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert "version" in payload
+
+
 # ── Edit assessment ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Why

The hosted demo (https://devops-maturity.onrender.com/) is slow on first hit because Render's free tier spins idle instances down (~15 min) and cold-starts them on the next request. The fix is to keep the instance warm with a periodic ping — which needs a cheap, dependency-free endpoint to hit.

## What

- **`src/web/main.py`** — new `GET /healthz` liveness probe returning `{"status": "ok", "version": <app version>}`. No DB access, no template rendering, so it's cheap to call frequently.
- **`tests/test_web.py`** — test covering `/healthz` (status + payload shape), matching the existing `TestClient` style.
- **`docs/deploy/hosting.md`** + **`mkdocs.yml`** nav — a "Hosting & keep-warm" guide: the cold-start explanation, keep-warm via an uptime monitor against `/healthz`, the free-tier instance-hours caveat, always-on alternatives (Render Starter / Fly.io / Railway), and the ephemeral-storage (SQLite) data-loss note. Wired into the nav since the docs build runs `mkdocs build --strict`.

## How to use it

Point an uptime monitor (UptimeRobot / cron-job.org) at `https://devops-maturity.onrender.com/healthz` every 5–10 min. The monitor lives in that service's dashboard — no repo config needed. Full steps in the new doc.

## Notes

- Additive only; no behaviour change to existing routes.
- `/healthz` doubles as a standard liveness/readiness probe if the app ever moves to a platform that supports health checks (Fly.io, k8s, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014T7TF835DAsBR9GMyZYjxC)_