### PR TITLE
ci(ods): enable report option on ODS validate action

### DIFF
--- a/.github/workflows/ods-validate.yml
+++ b/.github/workflows/ods-validate.yml
@@ -26,3 +26,4 @@ jobs:
           branch: ${{ github.head_ref }}
           summary: 'true'
           comment: 'true'
+          report: 'true'


### PR DESCRIPTION
## Summary

Enable the `report` option on the `open-delivery-spec/validate-action` step in `.github/workflows/ods-validate.yml` by adding `report: 'true'`.

Per the action's inputs, `report` (default `false`) appends an **AI attribution digest** to the job summary, the PR comment, and the uploaded artifact. This is **additive** — the existing `summary: 'true'` and `comment: 'true'` behavior is unchanged. The digest window defaults to `report-since: 90 days ago`; left at default here.

## Validation

- [x] `ods-validate.yml` parses as valid YAML.
- [ ] `nox -s tests` — n/a (CI workflow config only; no code changed)
- [ ] `nox -s lint` — n/a

## User impact

CI only. On pull requests, the ODS gate now also includes the AI attribution digest in its summary/comment/artifact output. No change to the CLI, web UI, docs, scoring, or packaging.

## Checklist

- [x] I added or updated tests for behavior changes. — n/a (no code/behavior change)
- [x] I updated documentation for user-facing changes. — n/a (internal CI workflow)
- [x] I removed secrets, tokens, and private repository data from examples and logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvJVX1BvZMmWAhu7YDCG89)_